### PR TITLE
Includes marker in the OSM link

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/location/SignalPlace.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/location/SignalPlace.java
@@ -64,7 +64,7 @@ public class SignalPlace {
     }
 
     if (BuildConfig.USE_OSM) {
-        description = "https://www.openstreetmap.org/#map=15/" + String.format("%s/%s", latitude, longitude);
+        description = "https://www.openstreetmap.org/?" + String.format( "mlat=%s&mlon=%s", latitude, longitude) + "#map=15/" + String.format("%s/%s", latitude, longitude);
     }
     else {
         description += Uri.parse(URL)


### PR DESCRIPTION
### Description of the problem
Currently, when using the osm location functionality, a link is created to the desired place but there is no indicator that points to the coordinates selected by the user. This is problematic when the other end does not have any app that is able to open openstreetmaps.org links as it is difficult to know for sure which place the sender specified.

### How this is solved
**Note that I haven't done any testing as I don't have the resources available to do so**
With this changes, when the link is opened, a blue marker points to the same place the sender intended and the receiver no longer needs to guess the exact position.
| Current         | Proposal     |
|--------------|-----------|
| https://www.openstreetmap.org/#map=19/37.81038/-122.47659 |   https://www.openstreetmap.org/?mlat=37.81038&mlon=-122.47659#map=19/37.81038/-122.47659  |
|   ![Without_Marker](https://user-images.githubusercontent.com/13437098/135668058-ef29ca4c-bc07-41fb-9ee0-79607c82faf1.png)    |     ![With_Marker](https://user-images.githubusercontent.com/13437098/135668113-f0da9829-f384-4448-a98f-c8d3d6bb4403.png)      |



### Future work
It could be interesting to implement [Shortlinks](https://wiki.openstreetmap.org/wiki/Shortlink), even though it could need some time